### PR TITLE
cache:clearconfigurationcache fails in TYPO3 < 6.0

### DIFF
--- a/Classes/Service/CacheApiService.php
+++ b/Classes/Service/CacheApiService.php
@@ -47,6 +47,9 @@ class Tx_Coreapi_Service_CacheApiService {
 	 * Clear all caches
 	 */
 	public function clearAllCaches() {
+		if (version_compare(TYPO3_version, '6.0.0', '<')) {
+			t3lib_extMgm::removeCacheFiles();
+		}
 		$this->tce->clear_cacheCmd('all');
 	}
 
@@ -61,6 +64,9 @@ class Tx_Coreapi_Service_CacheApiService {
 	 *
 	 */
 	public function clearConfigurationCache() {
+		if (version_compare(TYPO3_version, '6.0.0', '<')) {
+			t3lib_extMgm::removeCacheFiles();
+		}
 		$this->tce->clear_cacheCmd('temp_cached');
 	}
 


### PR DESCRIPTION
Fix #9 
