### PR TITLE
Extend DatabaseApi by a Method to import Static data

### DIFF
--- a/Classes/Command/DatabaseApiCommandController.php
+++ b/Classes/Command/DatabaseApiCommandController.php
@@ -57,6 +57,22 @@ class Tx_Coreapi_Command_DatabaseApiCommandController extends Tx_Extbase_MVC_Con
 			$this->quit();
 		}
 	}
+
+	/**
+	 * Import ext_tables_static+adt.sql from extensionmanager
+	 */
+	public function importExtensionManagerRepositoryCommand() {
+		/** @var $service Tx_Coreapi_Service_DatabaseApiService */
+		$service = $this->objectManager->get('Tx_Coreapi_Service_DatabaseApiService');
+
+		$result = $service->importExtensionManagerRepository();
+		if ($result) {
+			$this->outputLine('Static data has been imported');
+		} else {
+			$this->outputLine('Static data could not ne imported, Error(s): %s', array(LF . implode(LF, $result)));
+			$this->quit();
+		}
+	}
 }
 
 ?>

--- a/Classes/Service/DatabaseApiService.php
+++ b/Classes/Service/DatabaseApiService.php
@@ -208,6 +208,20 @@ class Tx_Coreapi_Service_DatabaseApiService {
 		return $finalKeys;
 	}
 
+	/**
+	 * Import ext_tables_static+adt.sql from extensionmanager
+	 */
+	public function importExtensionManagerRepository() {
+		$rawDefinitions = t3lib_div::getUrl(t3lib_extMgm::extPath('extensionmanager') . 'ext_tables_static+adt.sql');
+		$statements = $this->sqlHandler->getStatementarray($rawDefinitions, 1);
+		foreach ($statements as $statement) {
+			if (trim($statement) !== '') {
+				$GLOBALS['TYPO3_DB']->admin_query($statement);
+			}
+		}
+		return TRUE;
+	}
+
 }
 
 ?>


### PR DESCRIPTION
Extend DatabaseApi by a Method to import Static data (from Extensionmanager)
This is needed when calling mschwemer's language:updatealltranslations with fresh(empty) Databases
