### PR TITLE
Add command " extensionapi:installlist" to install multiple extensions (comma separated) in one step

### DIFF
--- a/Classes/Command/ExtensionApiCommandController.php
+++ b/Classes/Command/ExtensionApiCommandController.php
@@ -215,6 +215,20 @@ class ExtensionApiCommandController extends CommandController {
 	}
 
 	/**
+	 * Install(activate) a comma separated list of extension.
+	 *
+	 * @param string $key The extension keys, separated by commata
+	 *
+	 * @return void
+	 */
+	public function installListCommand($keys) {
+		$keysArray = GeneralUtility::trimExplode(',', $keys, TRUE);
+		foreach ($keysArray as $key) {
+			$this->installCommand($key);
+		}
+	}
+
+	/**
 	 * UnInstall(deactivate) an extension.
 	 *
 	 * @param string $key The extension key

--- a/Classes/Command/ExtensionApiCommandController.php
+++ b/Classes/Command/ExtensionApiCommandController.php
@@ -217,7 +217,7 @@ class ExtensionApiCommandController extends CommandController {
 	/**
 	 * Install(activate) a comma separated list of extension.
 	 *
-	 * @param string $key The extension keys, separated by commata
+	 * @param string $keys The extension keys, separated by commata
 	 *
 	 * @return void
 	 */

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "etobi/coreapi",
+    "name": "rabe69/coreapi",
     "description": "Provides a simple to use API for common core features. Goal is to be able to do the most common tasks by CLI instead of doing it in the backend/browser.",
     "type": "typo3-cms-extension",
     "version": "1.1.1",

--- a/composer.json
+++ b/composer.json
@@ -13,5 +13,8 @@
             "name": "Stefano Kowalke"
         }
     ],
-    "minimum-stability": "dev"
+    "minimum-stability": "dev",
+    "require": {
+		"typo3/cms": "~6.2"
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,4 @@
         }
     ],
     "minimum-stability": "dev",
-    "require": {
-        "typo3/cms": "~6.2"
-    }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,5 +13,5 @@
             "name": "Stefano Kowalke"
         }
     ],
-    "minimum-stability": "dev",
+    "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,6 @@
     ],
     "minimum-stability": "dev",
     "require": {
-		"typo3/cms": "~6.2"
-	}
+        "typo3/cms": "~6.2"
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "rabe69/coreapi",
+    "name": "etobi/coreapi",
     "description": "Provides a simple to use API for common core features. Goal is to be able to do the most common tasks by CLI instead of doing it in the backend/browser.",
     "type": "typo3-cms-extension",
     "version": "1.1.1",


### PR DESCRIPTION
Usage example:
typo3/cli_dispatch.phpsh extbase  extensionapi:installlist static_info_tables,static_info_tables_de,tt_address,realurl