### PR TITLE
[FEATURE] Make part of factory default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,5 +13,12 @@
             "name": "Stefano Kowalke"
         }
     ],
+    "extra": {
+        "typo3/cms": {
+            "Package": {
+                "partOfFactoryDefault": true
+            }
+        }
+    },
     "minimum-stability": "dev"
 }


### PR DESCRIPTION
This extension provides many useful lowlevel functions and should be activated by default.

This only affects new TYPO3 CMS installations.