### PR TITLE
Exception with TYPO3 7

### DIFF
--- a/Classes/Command/BackendApiCommandController.php
+++ b/Classes/Command/BackendApiCommandController.php
@@ -56,7 +56,7 @@ class BackendApiCommandController extends CommandController {
 	 * Initialize the object
 	 */
 	public function initializeObject() {
-		$this->logger = $this->objectManager->get('\TYPO3\CMS\Core\Log\LogManager')->getLogger(__CLASS__);
+		$this->logger = $this->objectManager->get('TYPO3\CMS\Core\Log\LogManager')->getLogger(__CLASS__);
 	}
 
 	/**

--- a/Classes/Command/CacheApiCommandController.php
+++ b/Classes/Command/CacheApiCommandController.php
@@ -57,7 +57,7 @@ class CacheApiCommandController extends CommandController {
 	 * Initialize the object
 	 */
 	public function initializeObject() {
-		$this->logger = $this->objectManager->get('\TYPO3\CMS\Core\Log\LogManager')->getLogger(__CLASS__);
+		$this->logger = $this->objectManager->get('TYPO3\CMS\Core\Log\LogManager')->getLogger(__CLASS__);
 	}
 
 	/**

--- a/Classes/Command/DatabaseApiCommandController.php
+++ b/Classes/Command/DatabaseApiCommandController.php
@@ -58,7 +58,7 @@ class DatabaseApiCommandController extends CommandController {
 	 * Initialize the object
 	 */
 	public function initializeObject() {
-		$this->logger = $this->objectManager->get('\TYPO3\CMS\Core\Log\LogManager')->getLogger(__CLASS__);
+		$this->logger = $this->objectManager->get('TYPO3\CMS\Core\Log\LogManager')->getLogger(__CLASS__);
 	}
 
 	/**

--- a/Classes/Command/ExtensionApiCommandController.php
+++ b/Classes/Command/ExtensionApiCommandController.php
@@ -61,7 +61,7 @@ class ExtensionApiCommandController extends CommandController {
 	 * Initialize the object
 	 */
 	public function initializeObject() {
-		$this->logger = $this->objectManager->get('\TYPO3\CMS\Core\Log\LogManager')->getLogger(__CLASS__);
+		$this->logger = $this->objectManager->get('TYPO3\CMS\Core\Log\LogManager')->getLogger(__CLASS__);
 	}
 
 	/**

--- a/Classes/Command/SiteApiCommandController.php
+++ b/Classes/Command/SiteApiCommandController.php
@@ -59,7 +59,7 @@ class SiteApiCommandController extends CommandController {
 	 * Initialize the object
 	 */
 	public function initializeObject() {
-		$this->logger = $this->objectManager->get('\TYPO3\CMS\Core\Log\LogManager')->getLogger(__CLASS__);
+		$this->logger = $this->objectManager->get('TYPO3\CMS\Core\Log\LogManager')->getLogger(__CLASS__);
 	}
 
 	/**


### PR DESCRIPTION
Tried to use the extension with TYPO3 7.2 and experienced the following exception:

`$className "\TYPO3\CMS\Core\Log\LogManager" must not start with a backslash.`

The attached changes resolve the issue.