### PR TITLE
[BUGFIX] missing constants MAXIMUM_LINE_LENGTH added

### DIFF
--- a/Classes/Command/ExtensionApiCommandController.php
+++ b/Classes/Command/ExtensionApiCommandController.php
@@ -38,6 +38,8 @@ use TYPO3\CMS\Extbase\Mvc\Controller\CommandController;
  */
 class ExtensionApiCommandController extends CommandController {
 
+  const MAXIMUM_LINE_LENGTH = 79;
+
 	/**
 	 * @var \TYPO3\CMS\Core\Log\LogManager $logManager
 	 */

--- a/Classes/Command/SiteApiCommandController.php
+++ b/Classes/Command/SiteApiCommandController.php
@@ -36,6 +36,8 @@ use TYPO3\CMS\Extbase\Mvc\Controller\CommandController;
  */
 class SiteApiCommandController extends CommandController {
 
+  const MAXIMUM_LINE_LENGTH = 79;
+
 	/**
 	 * @var \TYPO3\CMS\Core\Log\LogManager $logManager
 	 */


### PR DESCRIPTION
Since 7.3.0 the MAXIMUM_LINE_LENGTH constants is no longer part of extbase's CommandController class. So executing tasks like siteapi:info won't work right now.