### PR TITLE
[BUGFIX] Changes self::MAXIMUM_LINE_LENGTH to ->output->getMaximumLineLength()

### DIFF
--- a/Classes/Command/ExtensionApiCommandController.php
+++ b/Classes/Command/ExtensionApiCommandController.php
@@ -96,7 +96,7 @@ class ExtensionApiCommandController extends CommandController {
 
 		$this->outputLine('');
 		$this->outputLine('EXTENSION "%s": %s %s', array(strtoupper($key), $data['em_conf']['version'], $data['em_conf']['state']));
-		$this->outputLine(str_repeat('-', self::MAXIMUM_LINE_LENGTH));
+		$this->outputLine(str_repeat('-', $this->output->getMaximumLineLength()));
 
 		$outputInformation = array();
 		$outputInformation['is installed'] = ($data['is_installed'] ? 'yes' : 'no');
@@ -133,7 +133,7 @@ class ExtensionApiCommandController extends CommandController {
 					}
 				}
 			} else {
-				$description = wordwrap($outputValue, self::MAXIMUM_LINE_LENGTH - 28, PHP_EOL . str_repeat(' ', 28), TRUE);
+				$description = wordwrap($outputValue, $this->output->getMaximumLineLength() - 28, PHP_EOL . str_repeat(' ', 28), TRUE);
 			}
 			$this->outputLine('%-2s%-25s %s', array(' ', $outputKey, $description));
 		}
@@ -164,11 +164,11 @@ class ExtensionApiCommandController extends CommandController {
 		foreach ($extensions as $key => $details) {
 			$title = $key . ' - ' . $details['version'] . '/' . $details['state'];
 			$description = $details['title'];
-			$description = wordwrap($description, self::MAXIMUM_LINE_LENGTH - 43, PHP_EOL . str_repeat(' ', 43), TRUE);
+			$description = wordwrap($description, $this->output->getMaximumLineLength() - 43, PHP_EOL . str_repeat(' ', 43), TRUE);
 			$this->outputLine('%-2s%-40s %s', array(' ', $title, $description));
 		}
 
-		$this->outputLine('%-2s%-40s', array(' ', str_repeat('-', self::MAXIMUM_LINE_LENGTH - 3)));
+		$this->outputLine('%-2s%-40s', array(' ', str_repeat('-', $this->output->getMaximumLineLength() - 3)));
 		$this->outputLine('  Total: ' . count($extensions) . ' extensions');
 		$this->logger->info('extensionApi:listInstalled executed successfully');
 	}

--- a/Classes/Command/SiteApiCommandController.php
+++ b/Classes/Command/SiteApiCommandController.php
@@ -87,7 +87,7 @@ class SiteApiCommandController extends CommandController {
 		$data = $this->siteApiService->getSiteInfo();
 
 		foreach ($data as $key => $value) {
-			$line = wordwrap($value, self::MAXIMUM_LINE_LENGTH - 43, PHP_EOL . str_repeat(' ', 43), TRUE);
+			$line = wordwrap($value, $this->output->getMaximumLineLength() - 43, PHP_EOL . str_repeat(' ', 43), TRUE);
 			$this->outputLine('%-2s%-40s %s', array(' ', $key, $line));
 		}
 


### PR DESCRIPTION
for compatibility after https://review.typo3.org/#/c/30743/11/typo3/sysext/extbase/Classes/Mvc/Controller/CommandController.php