### PR TITLE
Add autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,5 +13,10 @@
             "name": "Stefano Kowalke"
         }
     ],
-    "minimum-stability": "dev"
+    "minimum-stability": "dev",
+    "autoload": {
+		"psr-4": {
+			"Etobi\\CoreAPI\\": "Classes/"
+		}
+    }	
 }


### PR DESCRIPTION
To enable propper autoloading added the necessary configuration.

Without this configuration, no autoloading is available for installation through composer in TYPO3, and therefore no commands are available.