### PR TITLE
adds page-cache clearing by Tag functionality

### DIFF
--- a/Classes/Command/CacheApiCommandController.php
+++ b/Classes/Command/CacheApiCommandController.php
@@ -147,6 +147,20 @@ class CacheApiCommandController extends CommandController {
 	}
 
 	/**
+	 * Clear page cache by Tag.
+	 *
+	 * @param string $tag
+	 * @return void
+	 */
+	public function clearPageCacheByTagCommand($tag)
+	{
+		$this->cacheApiService->clearPageCacheByTag($tag);
+		$message = 'Page cache with tag ' . $tag . ' has been cleared.';
+		$this->logger->info($message);
+		$this->outputLine($message);
+	}
+
+	/**
 	 * Clear all caches except the page cache.
 	 * This is especially useful on big sites when you can't just drop the page cache.
 	 *

--- a/Classes/Service/CacheApiService.php
+++ b/Classes/Service/CacheApiService.php
@@ -115,6 +115,16 @@ class CacheApiService {
 	}
 
 	/**
+	 * Clear the page cache by tag.
+	 * @param string $tag
+	 * @return void
+	 */
+	public function clearPageCacheByTag($tag)
+	{
+		$this->dataHandler->clear_cacheCmd('cachetag:' . $tag);
+	}
+
+	/**
 	 * Clears the configuration cache.
 	 *
 	 * @return void


### PR DESCRIPTION
Hi,
we needed a more specific way to clear page caches via the coreapi.
The TYPO3 cachingFramework supports cache-tags on page-level (there is an extra field for that in page properties for 6.2+), so I added the corresponding API call/method.

Usage example: ....extbase coreapi:clearPageCacheByTag <tagname> clears cache for all pages having the <tagname> set in their properties